### PR TITLE
fix: implement cache isolation to resolve OAuth plugin conflicts (Issue #25)

### DIFF
--- a/lib/prompts/opencode-codex.ts
+++ b/lib/prompts/opencode-codex.ts
@@ -117,8 +117,10 @@ export async function getOpenCodeCodexPrompt(): Promise<string> {
 		cachedMeta = JSON.parse(metaContent);
 	} catch (error) {
 		// Cache doesn't exist or is invalid, will fetch fresh
-		const err = error as Error;
-		logError("Failed to read OpenCode prompt cache", { error: err.message });
+		const err = error as Error & { code?: string };
+		if (err.code !== "ENOENT") {
+			logError("Failed to read OpenCode prompt cache", { error: err.message });
+		}
 	}
 
 	// Validate cache format and handle conflicts
@@ -235,8 +237,10 @@ export async function getCachedPromptPrefix(chars = 50): Promise<string | null> 
 		const content = await readFile(filePath, "utf-8");
 		return content.substring(0, chars);
 	} catch (error) {
-		const err = error as Error;
-		logError("Failed to read cached OpenCode prompt prefix", { error: err.message });
+		const err = error as Error & { code?: string };
+		if (err.code !== "ENOENT") {
+			logError("Failed to read cached OpenCode prompt prefix", { error: err.message });
+		}
 		return null;
 	}
 }

--- a/lib/prompts/opencode-codex.ts
+++ b/lib/prompts/opencode-codex.ts
@@ -3,13 +3,14 @@
  *
  * Fetches and caches codex.txt system prompt from OpenCode's GitHub repository.
  * Uses ETag-based caching to efficiently track updates.
+ * Handles cache conflicts when switching between different Codex plugins.
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile, rename } from "node:fs/promises";
 import { recordCacheHit, recordCacheMiss } from "../cache/cache-metrics.js";
 import { openCodePromptCache } from "../cache/session-cache.js";
-import { logError } from "../logger.js";
-import { CACHE_FILES, CACHE_TTL_MS } from "../utils/cache-config.js";
+import { logError, logWarn, logInfo } from "../logger.js";
+import { CACHE_FILES, CACHE_TTL_MS, LEGACY_CACHE_FILES, PLUGIN_PREFIX } from "../utils/cache-config.js";
 import { getOpenCodePath } from "../utils/file-system-utils.js";
 
 const OPENCODE_CODEX_URL =
@@ -19,10 +20,69 @@ interface OpenCodeCacheMeta {
 	etag: string;
 	lastFetch?: string; // Legacy field for backwards compatibility
 	lastChecked: number; // Timestamp for rate limit protection
+	url?: string; // Track source URL for validation
 }
 
 /**
- * Fetch OpenCode's codex.txt prompt with ETag-based caching
+ * Check if legacy cache files exist and migrate them
+ * @param cacheDir - Cache directory path
+ */
+async function migrateLegacyCache(cacheDir: string): Promise<void> {
+	const legacyCachePath = getOpenCodePath("cache", LEGACY_CACHE_FILES.OPENCODE_CODEX);
+	const legacyMetaPath = getOpenCodePath("cache", LEGACY_CACHE_FILES.OPENCODE_CODEX_META);
+
+	try {
+		// Check if legacy files exist
+		const legacyContent = await readFile(legacyCachePath, "utf-8");
+		const legacyMeta = await readFile(legacyMetaPath, "utf-8");
+
+		// Legacy files found, migrate to our plugin-specific files
+		logWarn("Detected cache files from different plugin. Migrating to @openhax/codex cache...", {
+			legacyFiles: [LEGACY_CACHE_FILES.OPENCODE_CODEX, LEGACY_CACHE_FILES.OPENCODE_CODEX_META],
+		});
+
+		const newCachePath = getOpenCodePath("cache", CACHE_FILES.OPENCODE_CODEX);
+		const newMetaPath = getOpenCodePath("cache", CACHE_FILES.OPENCODE_CODEX_META);
+
+		// Copy to new locations
+		await writeFile(newCachePath, legacyContent, "utf-8");
+		await writeFile(newMetaPath, legacyMeta, "utf-8");
+
+		// Remove legacy files to prevent future conflicts
+		await rename(legacyCachePath, `${legacyCachePath}.backup.${Date.now()}`);
+		await rename(legacyMetaPath, `${legacyMetaPath}.backup.${Date.now()}`);
+
+		logInfo("Cache migration completed successfully. Using isolated @openhax/codex cache.");
+	} catch (error) {
+		// No legacy files or migration failed - continue normally
+		const err = error as Error & { code?: string };
+		if (err.code !== "ENOENT") {
+			logWarn("Cache migration failed, will continue with fresh cache", { error: err.message });
+		}
+	}
+}
+
+/**
+ * Validate cache format and detect conflicts
+ * @param cachedMeta - Cache metadata to validate
+ * @returns True if cache appears to be from our plugin
+ */
+function validateCacheFormat(cachedMeta: OpenCodeCacheMeta | null): boolean {
+	if (!cachedMeta) return false;
+
+	// Check if cache has expected structure for our plugin
+	// Legacy caches might have different URL or missing fields
+	const hasValidStructure = Boolean(
+		cachedMeta.etag &&
+			typeof cachedMeta.lastChecked === "number" &&
+			(cachedMeta.url === undefined || cachedMeta.url?.includes("sst/opencode")),
+	);
+
+	return hasValidStructure;
+}
+
+/**
+ * Fetch OpenCode's codex.txt prompt with ETag-based caching and conflict resolution
  * Uses HTTP conditional requests to efficiently check for updates
  *
  * Rate limit protection: Only checks GitHub if cache is older than 15 minutes
@@ -32,6 +92,7 @@ export async function getOpenCodeCodexPrompt(): Promise<string> {
 	const cacheDir = getOpenCodePath("cache");
 	const cacheFilePath = getOpenCodePath("cache", CACHE_FILES.OPENCODE_CODEX);
 	const cacheMetaPath = getOpenCodePath("cache", CACHE_FILES.OPENCODE_CODEX_META);
+
 	// Ensure cache directory exists (test expects mkdir to be called)
 	await mkdir(cacheDir, { recursive: true });
 
@@ -42,6 +103,9 @@ export async function getOpenCodeCodexPrompt(): Promise<string> {
 		return sessionEntry.data;
 	}
 	recordCacheMiss("opencodePrompt");
+
+	// Check for and migrate legacy cache files only when session cache misses
+	await migrateLegacyCache(cacheDir);
 
 	// Try to load cached content and metadata
 	let cachedContent: string | null = null;
@@ -57,10 +121,22 @@ export async function getOpenCodeCodexPrompt(): Promise<string> {
 		logError("Failed to read OpenCode prompt cache", { error: err.message });
 	}
 
-	// Rate limit protection: If cache is less than 15 minutes old, use it
+	// Validate cache format and handle conflicts
+	if (cachedMeta && !validateCacheFormat(cachedMeta)) {
+		logWarn("Detected incompatible cache format. Creating fresh cache for @openhax/codex...", {
+			cacheSource: cachedMeta.url || "unknown",
+			pluginPrefix: PLUGIN_PREFIX,
+		});
+
+		// Reset cache variables to force fresh fetch
+		cachedContent = null;
+		cachedMeta = null;
+	}
+
+	// Rate limit protection: If cache is less than 15 minutes old and valid, use it
 	if (cachedMeta?.lastChecked && Date.now() - cachedMeta.lastChecked < CACHE_TTL_MS && cachedContent) {
 		// Store in session cache for faster subsequent access
-		openCodePromptCache.set("main", { data: cachedContent, etag: cachedMeta.etag || undefined });
+		openCodePromptCache.set("main", { data: cachedContent, etag: cachedMeta?.etag || undefined });
 		return cachedContent;
 	}
 
@@ -85,7 +161,7 @@ export async function getOpenCodeCodexPrompt(): Promise<string> {
 			const content = await response.text();
 			const etag = response.headers.get("etag") || "";
 
-			// Save to cache with timestamp
+			// Save to cache with timestamp and plugin identifier
 			await writeFile(cacheFilePath, content, "utf-8");
 			await writeFile(
 				cacheMetaPath,
@@ -94,6 +170,7 @@ export async function getOpenCodeCodexPrompt(): Promise<string> {
 						etag,
 						lastFetch: new Date().toISOString(), // Keep for backwards compat
 						lastChecked: Date.now(),
+						url: OPENCODE_CODEX_URL, // Track source URL for validation
 					} satisfies OpenCodeCacheMeta,
 					null,
 					2,
@@ -109,6 +186,11 @@ export async function getOpenCodeCodexPrompt(): Promise<string> {
 
 		// Fallback to cache if available
 		if (cachedContent) {
+			logWarn("Using cached OpenCode prompt due to fetch failure", {
+				status: response.status,
+				cacheAge: cachedMeta ? Date.now() - cachedMeta.lastChecked : "unknown",
+			});
+			openCodePromptCache.set("main", { data: cachedContent, etag: cachedMeta?.etag || undefined });
 			return cachedContent;
 		}
 
@@ -119,9 +201,23 @@ export async function getOpenCodeCodexPrompt(): Promise<string> {
 
 		// Network error - fallback to cache
 		if (cachedContent) {
+			logWarn("Network error detected, using cached OpenCode prompt", {
+				error: err.message,
+				cacheAge: cachedMeta ? Date.now() - cachedMeta.lastChecked : "unknown",
+			});
+
 			// Store in session cache even for fallback
 			openCodePromptCache.set("main", { data: cachedContent, etag: cachedMeta?.etag || undefined });
 			return cachedContent;
+		}
+
+		// Provide helpful error message for cache conflicts
+		if (err.message.includes("404") || err.message.includes("ENOENT")) {
+			throw new Error(
+				`Failed to fetch OpenCode prompt and no valid cache available. ` +
+					`This may happen when switching between different Codex plugins. ` +
+					`Try clearing the cache with: rm -rf ~/.opencode/cache/opencode* && rm -rf ~/.opencode/cache/codex*`,
+			);
 		}
 
 		throw new Error(`Failed to fetch OpenCode codex.txt and no cache available: ${err.message}`);

--- a/lib/utils/cache-config.ts
+++ b/lib/utils/cache-config.ts
@@ -21,16 +21,35 @@ export const CACHE_DIRS = {
 } as const;
 
 /**
- * Cache file names
+ * Plugin identifier for cache isolation
+ */
+export const PLUGIN_PREFIX = "openhax-codex";
+
+/**
+ * Cache file names with plugin-specific prefix
  */
 export const CACHE_FILES = {
 	/** Codex instructions file */
-	CODEX_INSTRUCTIONS: "codex-instructions.md",
+	CODEX_INSTRUCTIONS: `${PLUGIN_PREFIX}-instructions.md`,
 	/** Codex instructions metadata file */
-	CODEX_INSTRUCTIONS_META: "codex-instructions-meta.json",
+	CODEX_INSTRUCTIONS_META: `${PLUGIN_PREFIX}-instructions-meta.json`,
 	/** OpenCode prompt file */
-	OPENCODE_CODEX: "opencode-codex.txt",
+	OPENCODE_CODEX: `${PLUGIN_PREFIX}-opencode-prompt.txt`,
 	/** OpenCode prompt metadata file */
+	OPENCODE_CODEX_META: `${PLUGIN_PREFIX}-opencode-prompt-meta.json`,
+} as const;
+
+/**
+ * Legacy cache file names (for migration)
+ */
+export const LEGACY_CACHE_FILES = {
+	/** Legacy Codex instructions file */
+	CODEX_INSTRUCTIONS: "codex-instructions.md",
+	/** Legacy Codex instructions metadata file */
+	CODEX_INSTRUCTIONS_META: "codex-instructions-meta.json",
+	/** Legacy OpenCode prompt file */
+	OPENCODE_CODEX: "opencode-codex.txt",
+	/** Legacy OpenCode prompt metadata file */
 	OPENCODE_CODEX_META: "opencode-codex-meta.json",
 } as const;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhax/codex",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "OpenHax Codex OAuth plugin for Opencode — bring your ChatGPT Plus/Pro subscription instead of API credits",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhax/codex",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenHax Codex OAuth plugin for Opencode — bring your ChatGPT Plus/Pro subscription instead of API credits",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/spec/issue-25-oauth-cache-conflicts.md
+++ b/spec/issue-25-oauth-cache-conflicts.md
@@ -1,0 +1,158 @@
+# Issue 25 – OAuth Cache Conflicts Between Plugins
+
+**Issue**: #25 (BUG) Plugin fails with confusing errors if started with the other oauth plugin's cache files
+
+## Context & Current Behavior
+
+- **Problem**: Users switching from `opencode-openai-codex-auth` to `@openhax/codex` encounter cache conflicts
+- **Root Cause**: Both plugins use the same cache directory (`~/.opencode/cache/`) but with different:
+  - Cache file formats
+  - Fetch URLs (different GitHub repositories)
+  - Metadata structures
+- **Error Message**: `Failed to fetch OpenCode codex.txt: 404 Failed to fetch OpenCode codex.txt from GitHub`
+- **User Impact**: Poor conversion experience, users think our plugin is broken
+
+## Current Cache Files
+
+- `lib/prompts/opencode-codex.ts:31-129` - Fetches from `sst/opencode` repo
+- `lib/utils/cache-config.ts:26-35` - Defines cache file names:
+  - `opencode-codex.txt` - OpenCode prompt content
+  - `opencode-codex-meta.json` - ETag and metadata
+- Cache location: `~/.opencode/cache/` (shared with other plugin)
+
+## Solution Strategy
+
+### 1. Plugin-Specific Cache Namespace
+
+**Goal**: Isolate our cache files from other plugins
+**Implementation**:
+
+- Add plugin identifier prefix to cache files
+- Use `openhax-codex-` prefix for all cache files
+- Update cache paths to use plugin-specific subdirectory
+
+### 2. Graceful Cache Migration & Validation
+
+**Goal**: Handle existing cache files gracefully
+**Implementation**:
+
+- Detect incompatible cache formats
+- Provide clear migration messages
+- Fallback to fresh fetch when cache is invalid
+- Don't fail with cryptic errors
+
+### 3. Enhanced Error Handling
+
+**Goal**: Better user experience during plugin switching
+**Implementation**:
+
+- Detect cache conflict scenarios
+- Provide helpful error messages
+- Suggest cache cleanup steps
+- Continue operation when possible
+
+## Implementation Plan
+
+### Phase 1: Plugin-Specific Cache Files
+
+1. Update `lib/utils/cache-config.ts`:
+   - Add plugin-specific cache file names
+   - Use `openhax-codex-` prefix
+2. Update `lib/prompts/opencode-codex.ts`:
+   - Use new cache file paths
+   - Maintain backward compatibility during migration
+3. Update `lib/prompts/codex.ts`:
+   - Apply same prefix to Codex instruction cache
+
+### Phase 2: Cache Validation & Migration
+
+1. Add cache format validation:
+   - Check if cache files are from our plugin
+   - Detect incompatible formats
+2. Implement graceful migration:
+   - Backup existing cache if needed
+   - Create fresh cache files
+   - Log migration actions
+
+### Phase 3: Enhanced Error Messages
+
+1. Improve error handling in `lib/prompts/opencode-codex.ts`:
+   - Detect cache conflict scenarios
+   - Provide actionable error messages
+2. Add cache cleanup guidance:
+   - Suggest manual cleanup steps
+   - Include commands for cache reset
+
+## Definition of Done / Requirements
+
+### Functional Requirements
+
+- [ ] Plugin uses isolated cache files with `openhax-codex-` prefix
+- [ ] Graceful handling of existing cache from other plugins
+- [ ] Clear error messages when cache conflicts are detected
+- [ ] Automatic cache migration without user intervention
+- [ ] Fallback to fresh fetch when cache is incompatible
+
+### Non-Functional Requirements
+
+- [ ] No breaking changes for existing users of our plugin
+- [ ] Backward compatibility with our current cache format
+- [ ] Performance impact is minimal (cache isolation overhead)
+- [ ] Error messages are actionable and user-friendly
+
+### Test Coverage
+
+- [ ] Tests for cache file isolation
+- [ ] Tests for cache migration scenarios
+- [ ] Tests for error handling with invalid cache
+- [ ] Tests for backward compatibility
+- [ ] Integration tests for plugin switching scenarios
+
+## Files to Modify
+
+### Core Changes
+
+- `lib/utils/cache-config.ts` - Plugin-specific cache file names
+- `lib/prompts/opencode-codex.ts` - Isolated cache paths + validation
+- `lib/prompts/codex.ts` - Apply prefix to Codex cache files
+
+### Test Updates
+
+- `test/prompts-opencode-codex.test.ts` - Update cache file paths
+- `test/prompts-codex.test.ts` - Test cache isolation
+- Add new tests for cache migration and conflict handling
+
+## User Experience Improvements
+
+### Before (Current)
+
+```
+ERROR Failed to fetch OpenCode codex.txt: 404 Failed to fetch OpenCode codex.txt from GitHub
+```
+
+### After (Target)
+
+```
+WARN Detected cache files from different plugin. Creating fresh cache for @openhax/codex...
+INFO Cache migration completed successfully.
+INFO Ready to use @openhax/codex with isolated cache.
+```
+
+## Migration Strategy
+
+### For New Users
+
+- No impact - will start with clean, isolated cache
+
+### For Existing Users
+
+- Automatic migration on first run
+- Preserve existing cache in backup location
+- No manual intervention required
+- Clear communication about migration
+
+### For Users Switching Between Plugins
+
+- Graceful cache conflict detection
+- Actionable error messages
+- Simple cache cleanup commands if needed

--- a/test/prompts-codex.test.ts
+++ b/test/prompts-codex.test.ts
@@ -30,8 +30,8 @@ vi.mock("node:os", () => ({
 
 describe("Codex Instructions Fetcher", () => {
 	const cacheDir = join("/mock-home", ".opencode", "cache");
-	const cacheFile = join(cacheDir, "codex-instructions.md");
-	const cacheMeta = join(cacheDir, "codex-instructions-meta.json");
+	const cacheFile = join(cacheDir, "openhax-codex-instructions.md");
+	const cacheMeta = join(cacheDir, "openhax-codex-instructions-meta.json");
 
 	beforeEach(() => {
 		files.clear();

--- a/test/prompts-opencode-codex.test.ts
+++ b/test/prompts-opencode-codex.test.ts
@@ -38,8 +38,8 @@ vi.mock("../lib/cache/cache-metrics.js", () => ({
 
 describe("OpenCode Codex Prompt Fetcher", () => {
 	const cacheDir = join("/mock-home", ".opencode", "cache");
-	const cacheFile = join(cacheDir, "opencode-codex.txt");
-	const cacheMetaFile = join(cacheDir, "opencode-codex-meta.json");
+	const cacheFile = join(cacheDir, "openhax-codex-opencode-prompt.txt");
+	const cacheMetaFile = join(cacheDir, "openhax-codex-opencode-prompt-meta.json");
 
 	beforeEach(() => {
 		files.clear();
@@ -70,6 +70,7 @@ describe("OpenCode Codex Prompt Fetcher", () => {
 			expect(recordCacheHitMock).toHaveBeenCalledWith("opencodePrompt");
 			expect(recordCacheMissMock).not.toHaveBeenCalled();
 			expect(readFileMock).not.toHaveBeenCalled();
+			expect(mkdirMock).toHaveBeenCalled(); // Should still call mkdir for cache directory
 		});
 
 		it("falls back to file cache when session cache misses", async () => {


### PR DESCRIPTION
# Issue 25 – OAuth Cache Conflicts Between Plugins

**Issue**: #25 (BUG) Plugin fails with confusing errors if started with the other oauth plugin's cache files

## Context & Current Behavior

- **Problem**: Users switching from `opencode-openai-codex-auth` to `@openhax/codex` encounter cache conflicts
- **Root Cause**: Both plugins use the same cache directory (`~/.opencode/cache/`) but with different:
  - Cache file formats
  - Fetch URLs (different GitHub repositories)
  - Metadata structures
- **Error Message**: `Failed to fetch OpenCode codex.txt: 404 Failed to fetch OpenCode codex.txt from GitHub`
- **User Impact**: Poor conversion experience, users think our plugin is broken

## Current Cache Files

- `lib/prompts/opencode-codex.ts:31-129` - Fetches from `sst/opencode` repo
- `lib/utils/cache-config.ts:26-35` - Defines cache file names:
  - `opencode-codex.txt` - OpenCode prompt content
  - `opencode-codex-meta.json` - ETag and metadata
- Cache location: `~/.opencode/cache/` (shared with other plugin)

## Solution Strategy

### 1. Plugin-Specific Cache Namespace

**Goal**: Isolate our cache files from other plugins
**Implementation**:

- Add plugin identifier prefix to cache files
- Use `openhax-codex-` prefix for all cache files
- Update cache paths to use plugin-specific subdirectory

### 2. Graceful Cache Migration & Validation

**Goal**: Handle existing cache files gracefully
**Implementation**:

- Detect incompatible cache formats
- Provide clear migration messages
- Fallback to fresh fetch when cache is invalid
- Don't fail with cryptic errors

### 3. Enhanced Error Handling

**Goal**: Better user experience during plugin switching
**Implementation**:

- Detect cache conflict scenarios
- Provide helpful error messages
- Suggest cache cleanup steps
- Continue operation when possible

## Implementation Plan

### Phase 1: Plugin-Specific Cache Files

1. Update `lib/utils/cache-config.ts`:
   - Add plugin-specific cache file names
   - Use `openhax-codex-` prefix
2. Update `lib/prompts/opencode-codex.ts`:
   - Use new cache file paths
   - Maintain backward compatibility during migration
3. Update `lib/prompts/codex.ts`:
   - Apply same prefix to Codex instruction cache

### Phase 2: Cache Validation & Migration

1. Add cache format validation:
   - Check if cache files are from our plugin
   - Detect incompatible formats
2. Implement graceful migration:
   - Backup existing cache if needed
   - Create fresh cache files
   - Log migration actions

### Phase 3: Enhanced Error Messages

1. Improve error handling in `lib/prompts/opencode-codex.ts`:
   - Detect cache conflict scenarios
   - Provide actionable error messages
2. Add cache cleanup guidance:
   - Suggest manual cleanup steps
   - Include commands for cache reset

## Definition of Done / Requirements

### Functional Requirements

- [ ] Plugin uses isolated cache files with `openhax-codex-` prefix
- [ ] Graceful handling of existing cache from other plugins
- [ ] Clear error messages when cache conflicts are detected
- [ ] Automatic cache migration without user intervention
- [ ] Fallback to fresh fetch when cache is incompatible

### Non-Functional Requirements

- [ ] No breaking changes for existing users of our plugin
- [ ] Backward compatibility with our current cache format
- [ ] Performance impact is minimal (cache isolation overhead)
- [ ] Error messages are actionable and user-friendly

### Test Coverage

- [ ] Tests for cache file isolation
- [ ] Tests for cache migration scenarios
- [ ] Tests for error handling with invalid cache
- [ ] Tests for backward compatibility
- [ ] Integration tests for plugin switching scenarios

## Files to Modify

### Core Changes

- `lib/utils/cache-config.ts` - Plugin-specific cache file names
- `lib/prompts/opencode-codex.ts` - Isolated cache paths + validation
- `lib/prompts/codex.ts` - Apply prefix to Codex cache files

### Test Updates

- `test/prompts-opencode-codex.test.ts` - Update cache file paths
- `test/prompts-codex.test.ts` - Test cache isolation
- Add new tests for cache migration and conflict handling

## User Experience Improvements

### Before (Current)

```
ERROR Failed to fetch OpenCode codex.txt: 404 Failed to fetch OpenCode codex.txt from GitHub
```

### After (Target)

```
WARN Detected cache files from different plugin. Creating fresh cache for @openhax/codex...
INFO Cache migration completed successfully.
INFO Ready to use @openhax/codex with isolated cache.
```

## Migration Strategy

### For New Users

- No impact - will start with clean, isolated cache

### For Existing Users

- Automatic migration on first run
- Preserve existing cache in backup location
- No manual intervention required
- Clear communication about migration

### For Users Switching Between Plugins

- Graceful cache conflict detection
- Actionable error messages
- Simple cache cleanup commands if needed