### PR TITLE
Improve Codex branding and prompt fetch resilience

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -459,7 +459,7 @@ DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/your-model-name
 
 Look for:
 ```
-[openai-codex-plugin] Model config lookup: "your-model-name" → normalized to "gpt-5-codex" for API {
+[openhax/codex] Model config lookup: "your-model-name" → normalized to "gpt-5-codex" for API {
   hasModelSpecificConfig: true,
   resolvedConfig: { ... }
 }

--- a/docs/development/ARCHITECTURE.md
+++ b/docs/development/ARCHITECTURE.md
@@ -193,13 +193,13 @@ The plugin logs ID filtering for debugging:
 
 ```typescript
 // Before filtering
-console.log(`[openai-codex-plugin] Filtering ${originalIds.length} message IDs from input:`, originalIds);
+console.log(`[openhax/codex] Filtering ${originalIds.length} message IDs from input:`, originalIds);
 
 // After filtering
-console.log(`[openai-codex-plugin] Successfully removed all ${originalIds.length} message IDs`);
+console.log(`[openhax/codex] Successfully removed all ${originalIds.length} message IDs`);
 
 // Or warning if IDs remain
-console.warn(`[openai-codex-plugin] WARNING: ${remainingIds.length} IDs still present after filtering:`, remainingIds);
+console.warn(`[openhax/codex] WARNING: ${remainingIds.length} IDs still present after filtering:`, remainingIds);
 ```
 
 **Source**: `lib/request/request-transformer.ts:287-301`

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -375,8 +375,8 @@ DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5-codex-low
 #### Case 1: Custom Model with Config
 
 ```
-[openai-codex-plugin] Debug logging ENABLED
-[openai-codex-plugin] Model config lookup: "gpt-5-codex-low" → normalized to "gpt-5-codex" for API {
+[openhax/codex] Debug logging ENABLED
+[openhax/codex] Model config lookup: "gpt-5-codex-low" → normalized to "gpt-5-codex" for API {
   hasModelSpecificConfig: true,
   resolvedConfig: {
     reasoningEffort: 'low',
@@ -385,7 +385,7 @@ DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5-codex-low
     include: ['reasoning.encrypted_content']
   }
 }
-[openai-codex-plugin] Filtering 0 message IDs from input: []
+[openhax/codex] Filtering 0 message IDs from input: []
 ```
 
 ✅ **Verify:** `hasModelSpecificConfig: true` confirms per-model options found
@@ -399,8 +399,8 @@ DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5-codex
 ```
 
 ```
-[openai-codex-plugin] Debug logging ENABLED
-[openai-codex-plugin] Model config lookup: "gpt-5-codex" → normalized to "gpt-5-codex" for API {
+[openhax/codex] Debug logging ENABLED
+[openhax/codex] Model config lookup: "gpt-5-codex" → normalized to "gpt-5-codex" for API {
   hasModelSpecificConfig: false,
   resolvedConfig: {
     reasoningEffort: 'medium',
@@ -409,7 +409,7 @@ DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5-codex
     include: ['reasoning.encrypted_content']
   }
 }
-[openai-codex-plugin] Filtering 0 message IDs from input: []
+[openhax/codex] Filtering 0 message IDs from input: []
 ```
 
 ✅ **Verify:** `hasModelSpecificConfig: false` confirms using global options
@@ -419,8 +419,8 @@ DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5-codex
 #### Case 3: Multi-Turn with ID Filtering
 
 ```
-[openai-codex-plugin] Filtering 3 message IDs from input: ['msg_abc123', 'rs_xyz789', 'msg_def456']
-[openai-codex-plugin] Successfully removed all 3 message IDs
+[openhax/codex] Filtering 3 message IDs from input: ['msg_abc123', 'rs_xyz789', 'msg_def456']
+[openhax/codex] Successfully removed all 3 message IDs
 ```
 
 ✅ **Verify:** All IDs removed, no warnings
@@ -430,7 +430,7 @@ DEBUG_CODEX_PLUGIN=1 opencode run "test" --model=openai/gpt-5-codex
 #### Case 4: Warning if IDs Leak (Should Never Happen)
 
 ```
-[openai-codex-plugin] WARNING: 1 IDs still present after filtering: ['msg_abc123']
+[openhax/codex] WARNING: 1 IDs still present after filtering: ['msg_abc123']
 ```
 
 ❌ **This would indicate a bug** - should never appear

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -4,7 +4,7 @@
  */
 
 /** Plugin identifier for logging and error messages */
-export const PLUGIN_NAME = "openai-codex-plugin";
+export const PLUGIN_NAME = "openhax/codex";
 
 /** Base URL for ChatGPT backend API */
 export const CODEX_BASE_URL = "https://chatgpt.com/backend-api";

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -142,7 +142,7 @@ function logToConsole(
 	error?: unknown,
 ): void {
 	const shouldLog = CONSOLE_LOGGING_ENABLED || level === "warn" || level === "error";
-	if (IS_TEST_ENV && !shouldLog) {
+	if (!shouldLog) {
 		return;
 	}
 	const prefix = `[${PLUGIN_NAME}] ${message}`;

--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -1,3 +1,4 @@
+import { PLUGIN_NAME } from "../constants.js";
 import { LOGGING_ENABLED, logError, logRequest } from "../logger.js";
 import type { SSEEventData } from "../types.js";
 
@@ -35,7 +36,7 @@ function parseSseStream(sseText: string): unknown | null {
  */
 export async function convertSseToJson(response: Response, headers: Headers): Promise<Response> {
 	if (!response.body) {
-		throw new Error("[openhax/codex] Response has no body");
+		throw new Error(`${PLUGIN_NAME} Response has no body`);
 	}
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();

--- a/lib/request/response-handler.ts
+++ b/lib/request/response-handler.ts
@@ -35,7 +35,7 @@ function parseSseStream(sseText: string): unknown | null {
  */
 export async function convertSseToJson(response: Response, headers: Headers): Promise<Response> {
 	if (!response.body) {
-		throw new Error("[openai-codex-plugin] Response has no body");
+		throw new Error("[openhax/codex] Response has no body");
 	}
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();

--- a/spec/handle-missing-codex-prompt-warming.md
+++ b/spec/handle-missing-codex-prompt-warming.md
@@ -1,0 +1,31 @@
+# Handle missing codex prompt warming
+
+## Scope
+- Review uncommitted changes on branch `chore/handle-missing-codex-prompt-warming` for plugin log prefix and fallback prompt fetch handling.
+
+## Relevant files & line notes
+- `lib/constants.ts`:6-8 rename `PLUGIN_NAME` to `openhax/codex` for logging identity.
+- `lib/logger.ts`:144-158 log gating simplified to always mirror warn/error/info when enabled; removes test-env suppression.
+- `lib/prompts/opencode-codex.ts`:15-131 adds dev+main fallback URLs, stores `sourceUrl`, handles 304/etag per-source, logs last error, caches when available.
+- `lib/request/response-handler.ts`:36-79 updates empty-body error prefix to new plugin name.
+- Tests updated for new prefixes and caching behavior: `test/auth.test.ts`, `test/constants.test.ts`, `test/logger.test.ts`, `test/prompts-codex.test.ts`, `test/prompts-opencode-codex.test.ts` (new legacy URL fallback test).
+- Docs updated to reflect new logging prefix: `docs/configuration.md`, `docs/development/ARCHITECTURE.md`, `docs/development/TESTING.md`.
+
+## Existing issues / PRs
+- No linked issues or PRs referenced in the changes.
+
+## Requirements
+- Ensure logging prefix consistently uses `openhax/codex` across code, tests, docs.
+- OpenCode prompt fetcher should fall back to main branch when dev URL fails, preserving cache metadata including source URL.
+- Maintain ETag-based caching and cache-hit/miss metrics with session/file caches.
+- Tests should cover prefix changes and new fallback path.
+
+## Definition of done
+- All modified files aligned on new plugin identifier.
+- OpenCode codex prompt fetch resilient when dev URL missing; cache metadata persists `sourceUrl` and uses correct conditional requests.
+- Unit tests updated/passing; docs reflect logging prefix.
+- Branch ready with meaningful commit(s) and PR targeted to staging.
+
+## Notes
+- Untracked spec files present (`spec/opencode-prompt-cache-404.md`, `spec/plugin-name-rename.md`); keep intact.
+- Build/test commands: `npm test`, `npm run build`, `npm run typecheck` per AGENTS.md.

--- a/spec/opencode-prompt-cache-404.md
+++ b/spec/opencode-prompt-cache-404.md
@@ -1,0 +1,25 @@
+# OpenCode Prompt Cache 404
+
+## Context
+- Timestamped warnings during startup show `getOpenCodeCodexPrompt` failing to seed cache due to 404 on codex.txt (logs at 2025-11-19, default config path missing).
+- Current fetch URL targets `sst/opencode` on the `main` branch, which no longer hosts `packages/opencode/src/session/prompt/codex.txt`.
+
+## Existing Issues / PRs
+- No related issues/PRs reviewed yet; check backlog if needed.
+
+## Code Files & References
+- lib/prompts/opencode-codex.ts:15 – `OPENCODE_CODEX_URL` points to raw GitHub main branch and returns 404.
+- lib/cache/cache-warming.ts:41-99 – startup warming logs errors when `getOpenCodeCodexPrompt` fails.
+- lib/utils/file-system-utils.ts:15-23 – cache path under `~/.opencode/cache` used for prompt storage.
+- test/prompts-opencode-codex.test.ts:82-297 – coverage for caching, TTL, and fetch fallback behavior.
+
+## Definition of Done
+1. Update OpenCode prompt fetch logic to use a valid source and avoid 404s.
+2. Preserve caching semantics (session + disk + TTL) and existing metrics behavior.
+3. Ensure cache warming no longer logs repeated OpenCode fetch errors when network is available.
+4. Tests cover the new fetch path/fallback path and continue to pass.
+
+## Requirements
+- Add a resilient fetch strategy (e.g., prefer current branch/file path with fallback to legacy path) without breaking existing interfaces.
+- Keep cache directory/filenames unchanged to avoid disrupting existing users.
+- Maintain log levels (warn on failures) but succeed when a fallback fetch works.

--- a/spec/plugin-name-rename.md
+++ b/spec/plugin-name-rename.md
@@ -1,0 +1,18 @@
+# Plugin name rename to npm package name
+
+## Context
+- Update plugin/service identifier to use the npm package name `openhax/codex`.
+
+## Relevant code
+- lib/constants.ts:7 exports `PLUGIN_NAME` that is used for logging.
+- test/constants.test.ts:18-21 asserts the current plugin identity string.
+
+## Tasks / Plan
+1. Change `PLUGIN_NAME` to `openhax/codex` in `lib/constants.ts`.
+2. Update tests and any string expectations to the new identifier.
+3. Keep docs/examples consistent if they explicitly show the service name.
+
+## Definition of done
+- Plugin logs use `openhax/codex` as the service name.
+- Tests updated to match the new identifier and pass locally if run.
+- No references to the legacy identifier remain in code/tests relevant to logging.

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -205,7 +205,7 @@ describe("Auth Module", () => {
 			const result = await exchangeAuthorizationCode("code", "verifier");
 			expect(result).toEqual({ type: "failed" });
 			expect(console.error).toHaveBeenCalledWith(
-				'[openai-codex-plugin] Authorization code exchange failed {"status":400,"body":"bad request"}',
+				'[openhax/codex] Authorization code exchange failed {"status":400,"body":"bad request"}',
 				"",
 			);
 		});
@@ -219,7 +219,7 @@ describe("Auth Module", () => {
 			fetchMock.mockResolvedValueOnce(badRes);
 			await exchangeAuthorizationCode("code", "verifier");
 			expect(console.error).toHaveBeenCalledWith(
-				'[openai-codex-plugin] Authorization code exchange failed {"status":500,"body":""}',
+				'[openhax/codex] Authorization code exchange failed {"status":500,"body":""}',
 				"",
 			);
 		});
@@ -232,7 +232,7 @@ describe("Auth Module", () => {
 			const result = await exchangeAuthorizationCode("code", "verifier");
 			expect(result).toEqual({ type: "failed" });
 			expect(console.error).toHaveBeenCalledWith(
-				'[openai-codex-plugin] Token response missing fields {"access_token":"only-access"}',
+				'[openhax/codex] Token response missing fields {"access_token":"only-access"}',
 				"",
 			);
 		});
@@ -274,7 +274,7 @@ describe("Auth Module", () => {
 			const result = await refreshAccessToken("refresh-token");
 			expect(result).toEqual({ type: "failed" });
 			expect(console.error).toHaveBeenCalledWith(
-				'[openai-codex-plugin] Token refresh failed {"status":401,"body":"denied"}',
+				'[openhax/codex] Token refresh failed {"status":401,"body":"denied"}',
 				"",
 			);
 		});
@@ -284,7 +284,7 @@ describe("Auth Module", () => {
 			const result = await refreshAccessToken("refresh-token");
 			expect(result).toEqual({ type: "failed" });
 			expect(console.error).toHaveBeenCalledWith(
-				'[openai-codex-plugin] Token refresh error {"error":"network down"}',
+				'[openhax/codex] Token refresh error {"error":"network down"}',
 				"",
 			);
 		});
@@ -298,7 +298,7 @@ describe("Auth Module", () => {
 			fetchMock.mockResolvedValueOnce(badRes);
 			await refreshAccessToken("refresh-token");
 			expect(console.error).toHaveBeenCalledWith(
-				'[openai-codex-plugin] Token refresh failed {"status":403,"body":""}',
+				'[openhax/codex] Token refresh failed {"status":403,"body":""}',
 				"",
 			);
 		});
@@ -310,7 +310,7 @@ describe("Auth Module", () => {
 			const result = await refreshAccessToken("refresh-token");
 			expect(result).toEqual({ type: "failed" });
 			expect(console.error).toHaveBeenCalledWith(
-				'[openai-codex-plugin] Token refresh response missing fields {"access_token":"only"}',
+				'[openhax/codex] Token refresh response missing fields {"access_token":"only"}',
 				"",
 			);
 		});

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -16,7 +16,7 @@ import {
 
 describe("General constants", () => {
 	it("exposes the codex plugin identity", () => {
-		expect(PLUGIN_NAME).toBe("openai-codex-plugin");
+		expect(PLUGIN_NAME).toBe("openhax/codex");
 		expect(PROVIDER_ID).toBe("openai");
 	});
 

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -106,7 +106,7 @@ describe("logger", () => {
 		logWarn("warning");
 		await flushRollingLogsForTest();
 
-		expect(warnSpy).toHaveBeenCalledWith("[openai-codex-plugin] warning");
+		expect(warnSpy).toHaveBeenCalledWith("[openhax/codex] warning");
 	});
 
 	it("logInfo does not mirror to console unless debug flag is set", async () => {
@@ -134,7 +134,7 @@ describe("logger", () => {
 		await flushRollingLogsForTest();
 
 		expect(warnSpy).toHaveBeenCalledWith(
-			'[openai-codex-plugin] Failed to persist request log {"stage":"stage-two","error":"boom"}',
+			'[openhax/codex] Failed to persist request log {"stage":"stage-two","error":"boom"}',
 		);
 		expect(fsMocks.appendFile).toHaveBeenCalled();
 	});
@@ -175,7 +175,7 @@ describe("logger", () => {
 		expect(appended).toContain('"message":"third"');
 		expect(appended).not.toContain('"message":"first"');
 		expect(warnSpy).toHaveBeenCalledWith(
-			'[openai-codex-plugin] Rolling log queue overflow; dropping oldest entries {"maxQueueLength":2}',
+			'[openhax/codex] Rolling log queue overflow; dropping oldest entries {"maxQueueLength":2}',
 		);
 	});
 });

--- a/test/prompts-codex.test.ts
+++ b/test/prompts-codex.test.ts
@@ -49,7 +49,6 @@ describe("Codex Instructions Fetcher", () => {
 		codexInstructionsCache.clear();
 	});
 
-
 	afterEach(() => {
 		// Cleanup global fetch if needed
 		delete (global as any).fetch;
@@ -137,11 +136,11 @@ describe("Codex Instructions Fetcher", () => {
 
 		expect(result).toBe("still-good");
 		expect(consoleError).toHaveBeenCalledWith(
-			'[openai-codex-plugin] Failed to fetch instructions from GitHub {"error":"HTTP 500"}',
+			'[openhax/codex] Failed to fetch instructions from GitHub {"error":"HTTP 500"}',
 			"",
 		);
 		expect(consoleError).toHaveBeenCalledWith(
-			"[openai-codex-plugin] Using cached instructions due to fetch failure",
+			"[openhax/codex] Using cached instructions due to fetch failure",
 			"",
 		);
 		consoleError.mockRestore();
@@ -244,13 +243,10 @@ describe("Codex Instructions Fetcher", () => {
 
 		expect(typeof result).toBe("string");
 		expect(consoleError).toHaveBeenCalledWith(
-			'[openai-codex-plugin] Failed to fetch instructions from GitHub {"error":"HTTP 500"}',
+			'[openhax/codex] Failed to fetch instructions from GitHub {"error":"HTTP 500"}',
 			"",
 		);
-		expect(consoleError).toHaveBeenCalledWith(
-			"[openai-codex-plugin] Falling back to bundled instructions",
-			"",
-		);
+		expect(consoleError).toHaveBeenCalledWith("[openhax/codex] Falling back to bundled instructions", "");
 
 		const readPaths = readFileSync.mock.calls.map((call) => call[0] as string);
 		const fallbackPath = readPaths.find(


### PR DESCRIPTION
## Summary
- add gpt-5.1-codex-max support with config/docs/tests and persistent rolling logging
- rename the plugin identity to `openhax/codex` and align log prefixes
- make OpenCode codex prompt fetch resilient with dev/main fallbacks and cached source metadata

## Testing
- npm test -- test/prompts-opencode-codex.test.ts test/prompts-codex.test.ts test/logger.test.ts test/auth.test.ts test/constants.test.ts