### PR TITLE
Guard disk logging and clarify clone/role utilities

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -74,7 +74,8 @@ export function logRequest(stage: string, data: Record<string, unknown>): void {
 		stage,
 		...data,
 	};
-	const filePath = persistRequestStage(stage, payload);
+	const shouldPersist = LOGGING_ENABLED || DEBUG_ENABLED;
+	const filePath = shouldPersist ? persistRequestStage(stage, payload) : undefined;
 	const extra: Record<string, unknown> = {
 		stage,
 		requestId: payload.requestId,
@@ -117,7 +118,10 @@ function emit(level: LogLevel, message: string, extra?: Record<string, unknown>)
 		message,
 		extra: sanitizedExtra,
 	};
-	appendRollingLog(entry);
+
+	if (LOGGING_ENABLED || DEBUG_ENABLED) {
+		appendRollingLog(entry);
+	}
 
 	if (loggerClient?.app) {
 		void loggerClient.app

--- a/lib/session/session-manager.ts
+++ b/lib/session/session-manager.ts
@@ -150,6 +150,8 @@ function buildSessionKey(conversationId: string, forkId: string | undefined): st
 	return `${conversationId}::fork::${forkId}`;
 }
 
+// Keep in sync with ensurePromptCacheKey logic in request-transformer.ts so session-managed
+// and stateless flows derive identical cache keys.
 function buildPromptCacheKey(conversationId: string, forkId: string | undefined): string {
 	const sanitized = sanitizeCacheKey(conversationId);
 	if (!forkId) {

--- a/lib/utils/clone.ts
+++ b/lib/utils/clone.ts
@@ -7,6 +7,7 @@
 
 /**
  * Deep clone function that uses the best available method
+ * Note: Intended for JSON-serializable data (plain objects/arrays)
  * @param value - Value to clone
  * @returns Deep cloned value
  */
@@ -23,12 +24,18 @@ export function deepClone<T>(value: T): T {
 }
 
 /**
- * Clone an array of InputItems efficiently
+ * Clone an array of InputItems efficiently (expects a real array)
  * @param items - Array of InputItems to clone
  * @returns Cloned array
  */
-export function cloneInputItems<T>(items: T[]): T[] {
-	if (!Array.isArray(items) || items.length === 0) {
+export function cloneInputItems<T>(items?: T[] | null): T[] {
+	if (items == null) {
+		return [];
+	}
+	if (!Array.isArray(items)) {
+		throw new TypeError("cloneInputItems expects an array");
+	}
+	if (items.length === 0) {
 		return [];
 	}
 	return items.map((item) => deepClone(item));

--- a/lib/utils/input-item-utils.ts
+++ b/lib/utils/input-item-utils.ts
@@ -41,18 +41,9 @@ export function hasTextContent(item: InputItem): boolean {
  * @returns Formatted role name or empty string if invalid
  */
 export function formatRole(role: string): string {
-	const validRoles = [
-		"user",
-		"assistant",
-		"system",
-		"developer",
-		"function",
-		"function_call",
-		"function_call_output",
-	];
 	const normalized = (role ?? "").trim();
 	if (!normalized) return "";
-	return validRoles.includes(normalized) ? normalized : normalized;
+	return normalized;
 }
 
 /**

--- a/lib/utils/input-item-utils.ts
+++ b/lib/utils/input-item-utils.ts
@@ -50,7 +50,9 @@ export function formatRole(role: string): string {
 		"function_call",
 		"function_call_output",
 	];
-	return validRoles.includes(role) ? role : "";
+	const normalized = (role ?? "").trim();
+	if (!normalized) return "";
+	return validRoles.includes(normalized) ? normalized : normalized;
 }
 
 /**

--- a/spec/pr-33-coderabbit-review.md
+++ b/spec/pr-33-coderabbit-review.md
@@ -1,0 +1,35 @@
+# PR 33 coderabbitai review investigation
+
+## Reference
+
+- PR #33 **Guard disk logging and clarify clone/role utilities** (https://github.com/open-hax/codex/pull/33).
+- Single `coderabbitai[bot]` review (ID `3485713306`) submitted against commit `96a80ad907ee4767ea8367de9bbeb95703aa2098`.
+
+## Code files touched
+
+- `lib/utils/input-item-utils.ts:43-55` – `formatRole()` now normalizes the incoming `role` string and always returns the normalized value. The review thread pointed out the redundant ternary (`validRoles.includes(normalized) ? normalized : normalized`) and suggested simplifying the return to the normalized value.
+
+## Review threads
+
+- Review comment `2544369399` (https://github.com/open-hax/codex/pull/33#discussion_r2544369399)
+  - User `coderabbitai[bot]` classified the issue as _⚠️ Potential issue_ / _🟠 Major_.
+  - Actionable suggestion: after trimming and guarding the empty string, return `normalized` directly; drop the always-true `validRoles.includes` check.
+  - Status: resolved in the working tree (`formatRole` now fully returns `normalized` without the redundant includes check), so the PR can adopt the simplification before merging.
+
+## Existing issues / PRs
+
+- No other issues or PRs are referenced in PR #33 beyond the ones described above.
+
+## Requirements
+
+1. Collate every `coderabbitai[bot]` comment on PR #33.
+2. Capture the file/line context and actionable advice for each thread.
+3. Note any follow-up evidence that the comment was handled or still outstanding.
+4. Deliver a concise investigation summary for the user.
+
+## Definition of done
+
+- All coderabbitai review threads (IDs, URLs, severity, and suggested fixes) are documented with file/line context.
+- The investigation note makes clear whether the PR already incorporates the suggestion.
+- A short next-step recommendation is provided if any actions remain.
+- Next step: remove the redundant code, rerun lint/test that cover `formatRole`, and resolve the review comment before merging.


### PR DESCRIPTION
## Summary
- gate all disk logging behind logging/debug flags and adjust logger tests accordingly
- document JSON-only cloning, enforce array input for cloneInputItems, and prevent silent role stripping
- add note to align session prompt cache key derivation with request-transformer logic

## Testing
- pnpm test
- pnpm test:coverage
