### PR TITLE
Solidify PR auto-base workflow and staging docs

### DIFF
--- a/.github/workflows/pr-auto-base.yml
+++ b/.github/workflows/pr-auto-base.yml
@@ -13,6 +13,11 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Retarget PR to staging unless from staging
         run: |
           if [ "${GITHUB_BASE_REF}" = "staging" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,24 +9,28 @@ Before submitting contributions, please review these guidelines to ensure all ch
 All contributions MUST:
 
 ✅ **Maintain TOS Compliance**
+
 - Use only official OAuth authentication methods
 - Not facilitate violations of OpenAI's Terms of Service
 - Focus on legitimate personal productivity use cases
 - Include appropriate user warnings and disclaimers
 
 ✅ **Respect OpenAI's Systems**
+
 - No session token scraping or cookie extraction
 - No bypassing of rate limits or authentication controls
 - No reverse-engineering of undocumented APIs
 - Use only officially supported authentication flows
 
 ✅ **Proper Use Cases**
+
 - Personal development and coding assistance
 - Individual productivity enhancements
 - Terminal-based workflows
 - Educational purposes
 
 ❌ **Prohibited Features**
+
 - Commercial resale or multi-user authentication
 - Rate limit circumvention techniques
 - Session token scraping or extraction
@@ -43,13 +47,27 @@ All contributions MUST:
 
 ## Pull Request Process
 
-1. **Fork the repository** and create a feature branch
+1. **Fork the repository** and create a feature branch from `staging`
 2. **Write clear commit messages** explaining the "why" not just "what"
 3. **Include tests** for new functionality
 4. **Update documentation** (README.md, config examples, etc.)
 5. **Ensure compliance** with guidelines above
 6. **Test thoroughly** with actual ChatGPT Plus/Pro account
-7. **Submit PR** with clear description of changes
+7. **Submit PR** to `staging` with clear description of changes
+8. **Address review comments** - AI will automatically help generate fixes
+
+### Release Process
+
+All feature work targets the `staging` branch. When your PR merges to `staging`, it automatically:
+
+- Analyzes changes to determine release type (patch/minor/major)
+- Bumps the version in `package.json`
+- Creates an annotated git tag with release notes
+- Prepares for deployment to `main`
+
+For hotfixes, add the `hotfix` label to your PR before merging to trigger immediate release.
+
+See [Release Process Guide](docs/development/RELEASE_PROCESS.md) for complete details.
 
 ## Reporting Issues
 
@@ -64,6 +82,7 @@ When reporting issues, please:
 ### Issue Template
 
 Please include:
+
 ```
 **Issue Description:**
 [Clear description of the problem]
@@ -94,12 +113,14 @@ Please include:
 ## Feature Requests
 
 We welcome feature requests that:
+
 - Enhance personal productivity
 - Improve developer experience
 - Maintain compliance with OpenAI's terms
 - Align with the project's scope
 
 We will decline features that:
+
 - Violate or circumvent OpenAI's Terms of Service
 - Enable commercial resale or multi-user access
 - Bypass authentication or rate limiting
@@ -110,12 +131,14 @@ We will decline features that:
 ### Our Standards
 
 ✅ **Encouraged:**
+
 - Respectful and constructive communication
 - Focus on legitimate use cases
 - Transparency about limitations and compliance
 - Helping other users with proper usage
 
 ❌ **Not Acceptable:**
+
 - Requesting help with TOS violations
 - Promoting commercial misuse
 - Hostile or disrespectful behavior
@@ -124,6 +147,7 @@ We will decline features that:
 ## Questions?
 
 For questions about:
+
 - **Plugin usage:** Open a GitHub issue
 - **OpenAI's terms:** Contact OpenAI support
 - **Contributing:** Open a discussion thread

--- a/spec/retarget-workflow-fix.md
+++ b/spec/retarget-workflow-fix.md
@@ -1,0 +1,53 @@
+# PR Auto Base Retarget Fix
+
+## Problem
+
+The `pr-auto-base.yml` workflow was failing with the error:
+
+```
+failed to run git: fatal: not a git repository (or any of the parent directories): .git
+```
+
+This occurred because the workflow was trying to run `gh pr edit` without first checking out the repository, so there was no git context for the GitHub CLI to work with.
+
+## Solution
+
+Updated the workflow to:
+
+1. Add a checkout step using `actions/checkout@v4` with `fetch-depth: 0` to ensure full git history
+2. Keep the retarget logic that moves PRs to `staging` unless they already target `staging` or originate from `staging`
+
+## Code References
+
+- `.github/workflows/pr-auto-base.yml`: Checkout step at lines 16-20 ensures a git repository is available for GitHub CLI commands
+- `.github/workflows/pr-auto-base.yml`: Retarget logic at lines 22-32 switches PR base to `staging` unless the base is already `staging` or the head branch is `staging`
+- `CONTRIBUTING.md`: Pull request process and release process sections clarify `staging` as the default base and describe release automation (lines 49-69)
+
+## Existing Issues / PRs
+
+- No linked GitHub issues or PRs referenced in this change; fix derived from observed workflow failure logs
+
+## Files Changed
+
+- `.github/workflows/pr-auto-base.yml`: Added checkout step before the retarget logic
+- `CONTRIBUTING.md`: Clarified PR base branch guidance and documented release process that runs from `staging`
+
+## Definition of Done
+
+- Workflow runs without `fatal: not a git repository` errors
+- PRs opened against `main` are automatically retargeted to `staging`, except when they already target `staging` or originate from `staging`
+- Contributors are instructed to target `staging` and understand the release pipeline that runs post-merge
+
+## Requirements
+
+- GitHub-hosted runner with `gh` CLI available
+- `pull-requests: write` permission granted to the workflow; `GH_TOKEN` sourced from `secrets.GITHUB_TOKEN`
+- Repository must be checked out before invoking any `gh pr` commands
+
+## Testing
+
+The workflow should now successfully:
+
+- Check out the repository with full history
+- Run the retarget logic in a proper git context
+- Successfully retarget PRs from main to staging (except when PR is from staging branch)


### PR DESCRIPTION
## Summary
- add checkout to pr-auto-base workflow so gh pr edit has git context
- clarify CONTRIBUTING to target staging and outline release automation
- document the workflow fix and requirements in spec/retarget-workflow-fix.md

## Testing
- pnpm run typecheck (pre-push hook)