### PR TITLE
Ops: dev release flow hardening and ruleset drift guard

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -9,7 +9,7 @@ GH_TOKEN=<token_with_repo_admin> gh api repos/open-hax/codex/rulesets/10200441 >
 GH_TOKEN=<token_with_repo_admin> gh api repos/open-hax/codex/rulesets/10223971 > .github/rulesets/main.json
 ```
 
-After refreshing, commit changes. CI (`.github/workflows/ruleset-drift.yml`) fetches live rulesets, strips volatile timestamps (`created_at`, `updated_at`), normalizes with `jq -S .`, and diffs against these snapshots; it fails on structural drift.
+After refreshing, commit changes. CI (`.github/workflows/ruleset-drift.yml`) fetches live rulesets, strips volatile fields (`created_at`, `updated_at`, `bypass_actors`, `current_user_can_bypass`), normalizes with `jq -S .`, and diffs against these snapshots; it fails on structural drift only.
 
 ## Notes
 

--- a/.github/workflows/ruleset-drift.yml
+++ b/.github/workflows/ruleset-drift.yml
@@ -29,10 +29,10 @@ jobs:
           gh api repos/${{ github.repository }}/rulesets/10200441 > /tmp/rulesets/release.json
           gh api repos/${{ github.repository }}/rulesets/10223971 > /tmp/rulesets/main.json
 
-      - name: Normalize JSON (strip volatile timestamps)
+      - name: Normalize JSON (strip volatile fields)
         run: |
           mkdir -p /tmp/rulesets/normalized
-          strip='del(.created_at, .updated_at)'
+          strip='del(.created_at, .updated_at, .bypass_actors, .current_user_can_bypass)'
           jq -S "$strip" .github/rulesets/release.json > /tmp/rulesets/normalized/release.json
           jq -S "$strip" /tmp/rulesets/release.json > /tmp/rulesets/normalized/release.live.json
           jq -S "$strip" .github/rulesets/main.json > /tmp/rulesets/normalized/main.json


### PR DESCRIPTION
## Summary
- add CodeQL workflow on dev/main plus ruleset drift guard with normalization and timestamp/bypass stripping
- rename release flow to dev, align auto-base/merge guard, and document flow with mermaid
- add ruleset snapshots and ignore Obsidian files

## Testing
- CI
- CodeQL
- Ruleset drift check (will rerun after merge)
