### PR TITLE
Fix release prep reviewer step

### DIFF
--- a/.github/workflows/dev-release-prep.yml
+++ b/.github/workflows/dev-release-prep.yml
@@ -181,7 +181,6 @@ jobs:
             exit 1
           fi
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
-          gh api repos/$REPO/pulls/$PR_NUMBER/requested_reviewers -f reviewers[]="coderabbitai"
           gh api graphql -f query='mutation($prId:ID!,$method:PullRequestMergeMethod!){enablePullRequestAutoMerge(input:{pullRequestId:$prId,mergeMethod:$method}){pullRequest{number autoMergeRequest{enabledBy{login}}}}}' -f prId="$PR_NODE_ID" -f method=SQUASH
 
       - name: Create release tag


### PR DESCRIPTION
## Summary
- remove reviewer request from dev-release-prep (GH blocks Actions from requesting non-collaborator reviewers)

## Testing
- not run (workflow-only change)
