### PR TITLE
Skip release prep when merging release/* into dev

### DIFF
--- a/.github/workflows/dev-release-prep.yml
+++ b/.github/workflows/dev-release-prep.yml
@@ -6,6 +6,8 @@ on:
       - closed
     branches:
       - dev
+    paths-ignore:
+      - "release/**"
 
 permissions:
   contents: write
@@ -16,7 +18,7 @@ concurrency:
 
 jobs:
   prepare:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     env:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}


### PR DESCRIPTION
## Summary
- add paths-ignore and head ref guard so dev-release-prep does not run when merging release/* branches into dev (prevents re-entrant release PRs)

## Testing
- not run (workflow-only change)