### PR TITLE
chore: release v0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhax/codex",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "OpenHax Codex OAuth plugin for Opencode — bring your ChatGPT Plus/Pro subscription instead of API credits",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Release v0.3.5

- Source PR: #53
- Hotfix: false

### Release notes
## Summary
Fallback to patch because analyzer input could not be classified

### Release Type
- PATCH (auto-detected)

### Highlights
- 961a6fe skip dev-release-prep when head is release/*
- f463ff8 chore: release v0.3.4 (PR #50) (#51)
- 70a3e37 chore: release v0.3.3 (PR #48)
- 1179c50 chore: release v0.3.2 (PR #46)
- 443c621 remove reviewer request in release prep workflow