### PR TITLE
Handle Codex cache metadata on 304/fallback

### DIFF
--- a/spec/pr57-review.md
+++ b/spec/pr57-review.md
@@ -1,0 +1,24 @@
+# PR 57 review follow-up
+
+## Context
+- PR #57 (branch `dev` → `main`) reorganizes request handling and caching.
+- Unresolved review feedback targets Codex instruction caching metadata refresh logic in `lib/prompts/codex.ts`.
+
+## Review comments to address
+1) `lib/prompts/codex.ts` (approx lines 90-200): metadata `lastChecked` is not updated when GitHub returns 304 or when cached/bundled fallbacks are used after a fetch failure, causing repeated GitHub calls beyond TTL.
+
+## Plan
+- Inspect current `getCodexInstructions` flow and helpers to locate 304 + fallback paths.
+- Update metadata writes so `lastChecked` refreshes on 304 responses with valid cache and when cached/bundled fallbacks are used.
+- Ensure session cache is consistent and logging remains accurate.
+- Add/adjust tests in `test/prompts-codex.test.ts` (or neighboring files) to cover refreshed metadata on 304 and fallback.
+- Run targeted tests for prompts/codex logic.
+
+## Definition of done
+- Code change updates metadata refresh logic per review without altering successful fetch semantics.
+- Tests updated/added and passing locally for the touched area.
+- Worktree clean aside from intentional changes; review comment marked resolved.
+
+## Notes
+- Focus file: lib/prompts/codex.ts
+- Test focus: test/prompts-codex.test.ts


### PR DESCRIPTION
## Summary
- refresh Codex instructions cache metadata when using 304 responses or cached/bundled fallbacks to honor TTL
- add guard rails around cache writes and align tests with new metadata refresh behavior
- document review follow-up steps in spec/pr57-review.md

## Testing
- npm test -- test/prompts-codex.test.ts
