### PR TITLE
Avoid duplicate bridge on session reinject

### DIFF
--- a/lib/request/input-filters.ts
+++ b/lib/request/input-filters.ts
@@ -203,7 +203,19 @@ export function addCodexBridgeMessage(
 	const analysis = analyzeBridgeRequirement(input, hasTools);
 
 	if (sessionBridgeInjected) {
+		const alreadyPresent = hasBridgePromptInConversation(input, CODEX_OPENCODE_BRIDGE);
+		if (alreadyPresent) {
+			logDebug("Bridge prompt already present; preserving session continuity");
+			if (sessionContext) {
+				sessionContext.state.bridgeInjected = true;
+			}
+			return input;
+		}
+
 		logDebug("Bridge prompt previously injected in session; reapplying for continuity");
+		if (sessionContext) {
+			sessionContext.state.bridgeInjected = true;
+		}
 		return [bridgeMessage, ...input];
 	}
 

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -10,6 +10,7 @@ import {
 	addCodexBridgeMessage,
 	transformRequestBody as transformRequestBodyInternal,
 } from "../lib/request/request-transformer.js";
+import { CODEX_OPENCODE_BRIDGE } from "../lib/prompts/codex-opencode-bridge.js";
 import * as logger from "../lib/logger.js";
 import { SessionManager } from "../lib/session/session-manager.js";
 import type { RequestBody, SessionContext, UserConfig, InputItem } from "../lib/types.js";
@@ -651,6 +652,38 @@ describe("addCodexBridgeMessage", () => {
 		expect(result).toHaveLength(2);
 		expect(result?.[0].role).toBe("developer");
 		expect(result?.[1].role).toBe("user");
+		expect(sessionContext.state.bridgeInjected).toBe(true);
+	});
+
+	it("avoids duplicating bridge when already present in session", async () => {
+		const input: InputItem[] = [
+			{
+				type: "message",
+				role: "developer",
+				content: [{ type: "input_text", text: CODEX_OPENCODE_BRIDGE }],
+			},
+			{ type: "message", role: "user", content: "hello" },
+		];
+		const sessionContext: SessionContext = {
+			sessionId: "ses_bridge",
+			enabled: true,
+			preserveIds: true,
+			isNew: false,
+			state: {
+				id: "ses_bridge",
+				promptCacheKey: "ses_bridge",
+				store: false,
+				lastInput: [],
+				lastPrefixHash: null,
+				lastUpdated: Date.now(),
+				bridgeInjected: true,
+			},
+		};
+
+		const result = addCodexBridgeMessage(input, true, sessionContext);
+
+		expect(result).toEqual(input);
+		expect(result?.[0]).toEqual(input[0]);
 		expect(sessionContext.state.bridgeInjected).toBe(true);
 	});
 


### PR DESCRIPTION
## Summary
- when session marks bridge injected, check conversation for existing bridge before re-prepending
- maintain session flag while skipping duplicate
- add coverage to request-transformer tests

## Testing
- npm test -- test/request-transformer.test.ts
