### PR TITLE
Add configurable env tail append option

### DIFF
--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -124,7 +124,7 @@ export async function transformRequestForCodex(
 	userConfig: UserConfig,
 	codexMode = true,
 	sessionManager?: SessionManager,
-	_pluginConfig?: PluginConfig,
+	pluginConfig?: PluginConfig,
 ): Promise<
 	| {
 			body: RequestBody;
@@ -160,7 +160,9 @@ export async function transformRequestForCodex(
 			codexMode,
 			{
 				preserveIds: sessionContext?.preserveIds,
+				appendEnvContext: pluginConfig?.appendEnvContext ?? process.env.CODEX_APPEND_ENV_CONTEXT === "1",
 			},
+
 			sessionContext,
 		);
 		const appliedContext =

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,12 @@ export interface PluginConfig {
 	enablePromptCaching?: boolean;
 
 	/**
+	 * Reattach stripped environment/file context to the end of the prompt
+	 * Default inherits from CODEX_APPEND_ENV_CONTEXT env var
+	 */
+	appendEnvContext?: boolean;
+
+	/**
 	 * Logging configuration that can override environment variables
 	 */
 	logging?: LoggingConfig;

--- a/spec/append-env-context-config.md
+++ b/spec/append-env-context-config.md
@@ -1,0 +1,29 @@
+# Append Env Context Config
+
+## Scope
+
+- Add `appendEnvContext` to plugin config with default derived from `CODEX_APPEND_ENV_CONTEXT`.
+- Route env/file tail reattachment through config/options instead of global env in transforms.
+- Make tests explicit about env-tail behavior to avoid leaked env state.
+
+## Touched Files
+
+- lib/types.ts (PluginConfig additions)
+- lib/config.ts (default config from env, merge logic)
+- lib/request/request-transformer.ts (options-driven appendEnvContext handling)
+- lib/request/fetch-helpers.ts (propagate config to transform)
+- test/request-transformer.test.ts (explicit appendEnvContext expectations)
+- test/cache-e2e.test.ts (pass plugin config with appendEnvContext=false)
+- test/plugin-config.test.ts (cover env default + overrides, reset env)
+
+## Definition of Done
+
+- appendEnvContext configurable via config file with default from env.
+- Transform respects config-driven appendEnvContext; no hard env dependency in tests.
+- Cache/request-transformer tests pass with explicit config; plugin config tests cover new field.
+- pnpm test test/cache-e2e.test.ts test/request-transformer.test.ts test/plugin-config.test.ts succeeds.
+
+## Notes
+
+- No existing issues/PRs linked for this change.
+- Defaults recalc on load; `forceReload` picks up env changes.

--- a/test/cache-e2e.test.ts
+++ b/test/cache-e2e.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { transformRequestForCodex } from "../lib/request/fetch-helpers.js";
 import { SessionManager } from "../lib/session/session-manager.js";
 import * as openCodeCodex from "../lib/prompts/opencode-codex.js";

--- a/test/cache-e2e.test.ts
+++ b/test/cache-e2e.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { transformRequestForCodex } from "../lib/request/fetch-helpers.js";
 import { SessionManager } from "../lib/session/session-manager.js";
 import * as openCodeCodex from "../lib/prompts/opencode-codex.js";
-import type { InputItem, RequestBody, UserConfig } from "../lib/types.js";
+import type { InputItem, PluginConfig, RequestBody, UserConfig } from "../lib/types.js";
 import * as logger from "../lib/logger.js";
 
 const CODEX_INSTRUCTIONS = "codex instructions";
@@ -30,7 +30,11 @@ function envMessage(date: string, files: string[]): InputItem {
 	};
 }
 
-async function runTransform(body: RequestBody, sessionManager: SessionManager) {
+async function runTransform(
+	body: RequestBody,
+	sessionManager: SessionManager,
+	pluginConfig: PluginConfig = { appendEnvContext: false },
+) {
 	const init: RequestInit = { body: JSON.stringify(body) };
 	const result = await transformRequestForCodex(
 		init,
@@ -39,6 +43,7 @@ async function runTransform(body: RequestBody, sessionManager: SessionManager) {
 		USER_CONFIG,
 		true,
 		sessionManager,
+		pluginConfig,
 	);
 	if (!result) throw new Error("transformRequestForCodex returned undefined");
 	return result;

--- a/test/plugin-config.test.ts
+++ b/test/plugin-config.test.ts
@@ -29,9 +29,13 @@ beforeEach(async () => {
 
 describe("Plugin Configuration", () => {
 	let originalEnv: string | undefined;
+	let originalAppendEnv: string | undefined;
 
 	beforeEach(() => {
 		originalEnv = process.env.CODEX_MODE;
+		originalAppendEnv = process.env.CODEX_APPEND_ENV_CONTEXT;
+		delete process.env.CODEX_MODE;
+		delete process.env.CODEX_APPEND_ENV_CONTEXT;
 		vi.clearAllMocks();
 	});
 
@@ -40,6 +44,12 @@ describe("Plugin Configuration", () => {
 			delete process.env.CODEX_MODE;
 		} else {
 			process.env.CODEX_MODE = originalEnv;
+		}
+
+		if (originalAppendEnv === undefined) {
+			delete process.env.CODEX_APPEND_ENV_CONTEXT;
+		} else {
+			process.env.CODEX_APPEND_ENV_CONTEXT = originalAppendEnv;
 		}
 	});
 
@@ -52,6 +62,7 @@ describe("Plugin Configuration", () => {
 			expect(config).toEqual({
 				codexMode: true,
 				enablePromptCaching: true,
+				appendEnvContext: false,
 				logging: { showWarningToasts: false, logWarningsToConsole: false },
 			});
 
@@ -69,6 +80,7 @@ describe("Plugin Configuration", () => {
 			expect(config).toEqual({
 				codexMode: false,
 				enablePromptCaching: true,
+				appendEnvContext: false,
 				logging: { showWarningToasts: false, logWarningsToConsole: false },
 			});
 		});
@@ -82,8 +94,28 @@ describe("Plugin Configuration", () => {
 			expect(config).toEqual({
 				codexMode: true,
 				enablePromptCaching: true,
+				appendEnvContext: false,
 				logging: { showWarningToasts: false, logWarningsToConsole: false },
 			});
+		});
+
+		it("should default appendEnvContext from env when config missing", () => {
+			process.env.CODEX_APPEND_ENV_CONTEXT = "1";
+			mockExistsSync.mockReturnValue(false);
+
+			const config = loadPluginConfig({ forceReload: true });
+
+			expect(config.appendEnvContext).toBe(true);
+		});
+
+		it("should let config override appendEnvContext even when env is set", () => {
+			process.env.CODEX_APPEND_ENV_CONTEXT = "1";
+			mockExistsSync.mockReturnValue(true);
+			mockReadFileSync.mockReturnValue(JSON.stringify({ appendEnvContext: false }));
+
+			const config = loadPluginConfig({ forceReload: true });
+
+			expect(config.appendEnvContext).toBe(false);
 		});
 
 		it("should merge nested logging config with defaults", () => {
@@ -112,6 +144,7 @@ describe("Plugin Configuration", () => {
 			expect(config).toEqual({
 				codexMode: true,
 				enablePromptCaching: true,
+				appendEnvContext: false,
 				logging: { showWarningToasts: false, logWarningsToConsole: false },
 			});
 
@@ -131,6 +164,7 @@ describe("Plugin Configuration", () => {
 			expect(config).toEqual({
 				codexMode: true,
 				enablePromptCaching: true,
+				appendEnvContext: false,
 				logging: { showWarningToasts: false, logWarningsToConsole: false },
 			});
 			expect(logWarnSpy).toHaveBeenCalled();

--- a/test/request-transformer.test.ts
+++ b/test/request-transformer.test.ts
@@ -714,7 +714,14 @@ describe("transformRequestBody caching stability", () => {
 			],
 		};
 
-		const result1 = await transformRequestBody(body1, CODEX_INSTRUCTIONS, userConfig, true, {}, undefined);
+		const result1 = await transformRequestBody(
+			body1,
+			CODEX_INSTRUCTIONS,
+			userConfig,
+			true,
+			{ appendEnvContext: false },
+			undefined,
+		);
 		expect(result1.prompt_cache_key).toContain("conv-env-stable");
 		expect(result1.input).toHaveLength(1);
 		expect(result1.input?.[0].role).toBe("user");
@@ -728,14 +735,20 @@ describe("transformRequestBody caching stability", () => {
 			],
 		};
 
-		const result2 = await transformRequestBody(body2, CODEX_INSTRUCTIONS, userConfig, true, {}, undefined);
+		const result2 = await transformRequestBody(
+			body2,
+			CODEX_INSTRUCTIONS,
+			userConfig,
+			true,
+			{ appendEnvContext: false },
+			undefined,
+		);
 		expect(result2.prompt_cache_key).toBe(result1.prompt_cache_key);
 		expect(result2.input).toHaveLength(1);
 		expect(result2.input?.[0].role).toBe("user");
 	});
 
 	it("can reattach env/files tail when flag enabled", async () => {
-		process.env.CODEX_APPEND_ENV_CONTEXT = "1";
 		const body: RequestBody = {
 			model: "gpt-5",
 			metadata: { conversation_id: "conv-env-tail" },
@@ -762,14 +775,19 @@ describe("transformRequestBody caching stability", () => {
 			],
 		};
 
-		const result = await transformRequestBody(body, CODEX_INSTRUCTIONS, userConfig, true, {}, undefined);
+		const result = await transformRequestBody(
+			body,
+			CODEX_INSTRUCTIONS,
+			userConfig,
+			true,
+			{ appendEnvContext: true },
+			undefined,
+		);
 		expect(result.input?.length).toBe(2);
 		expect(result.input?.[0].role).toBe("user");
 		expect(result.input?.[1].role).toBe("developer");
 		expect(result.input?.[1].content as string).toContain("<env>");
 		expect(result.input?.[1].content as string).toContain("<files>");
-
-		delete process.env.CODEX_APPEND_ENV_CONTEXT;
 	});
 });
 


### PR DESCRIPTION
## Summary
- add appendEnvContext plugin config defaulting from CODEX_APPEND_ENV_CONTEXT and pass through transforms
- ensure request/cache transforms use config flag instead of ambient env and document the behavior
- make related tests explicit about env tail handling and add coverage for config/env defaults

## Testing
- pnpm test test/cache-e2e.test.ts test/request-transformer.test.ts test/plugin-config.test.ts