### PR TITLE
Add eta-mu GitHub workflows

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -5,26 +5,52 @@
   "source_type": "Repository",
   "source": "open-hax/codex",
   "enforcement": "active",
-  "conditions": { "ref_name": { "exclude": [], "include": ["refs/heads/main"] } },
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/main"
+      ]
+    }
+  },
   "rules": [
-    { "type": "deletion" },
-    { "type": "non_fast_forward" },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
     {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "Test (20.x)", "integration_id": 15368 },
-          { "context": "Test (22.x)", "integration_id": 15368 },
-          { "context": "Lint & Typecheck", "integration_id": 15368 },
-          { "context": "CodeRabbit", "integration_id": 347564 }
+          {
+            "context": "Test (20.x)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Test (22.x)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Lint & Typecheck",
+            "integration_id": 15368
+          },
+          {
+            "context": "CodeRabbit",
+            "integration_id": 347564
+          }
         ]
       }
     },
     {
       "type": "copilot_code_review",
-      "parameters": { "review_on_push": true, "review_draft_pull_requests": true }
+      "parameters": {
+        "review_on_push": true,
+        "review_draft_pull_requests": true
+      }
     },
     {
       "type": "pull_request",
@@ -35,11 +61,19 @@
         "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true,
-        "automatic_copilot_code_review_enabled": true,
-        "allowed_merge_methods": ["merge", "squash", "rebase"]
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
       }
     },
-    { "type": "code_quality", "parameters": { "severity": "errors" } },
+    {
+      "type": "code_quality",
+      "parameters": {
+        "severity": "errors"
+      }
+    },
     {
       "type": "code_scanning",
       "parameters": {
@@ -53,19 +87,26 @@
       }
     },
     {
-      "type": "copilot_code_review_analysis_tools",
-      "parameters": { "tools": [{ "name": "CodeQL" }, { "name": "ESLint" }] }
+      "type": "copilot_code_review"
     }
   ],
   "node_id": "RRS_lACqUmVwb3NpdG9yec5AmajgzgCcAWM",
   "created_at": "2025-11-20T12:56:31.538-06:00",
   "updated_at": "2025-11-20T13:34:49.695-06:00",
   "bypass_actors": [
-    { "actor_id": null, "actor_type": "OrganizationAdmin", "bypass_mode": "always" }
+    {
+      "actor_id": null,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
   ],
   "current_user_can_bypass": "always",
   "_links": {
-    "self": { "href": "https://api.github.com/repos/open-hax/codex/rulesets/10223971" },
-    "html": { "href": "https://github.com/open-hax/codex/rules/10223971" }
+    "self": {
+      "href": "https://api.github.com/repos/open-hax/codex/rulesets/10223971"
+    },
+    "html": {
+      "href": "https://github.com/open-hax/codex/rules/10223971"
+    }
   }
 }

--- a/.github/rulesets/release.json
+++ b/.github/rulesets/release.json
@@ -5,13 +5,27 @@
   "source_type": "Repository",
   "source": "open-hax/codex",
   "enforcement": "active",
-  "conditions": { "ref_name": { "exclude": [], "include": ["~DEFAULT_BRANCH"] } },
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
   "rules": [
-    { "type": "deletion" },
-    { "type": "non_fast_forward" },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
     {
       "type": "copilot_code_review",
-      "parameters": { "review_on_push": true, "review_draft_pull_requests": false }
+      "parameters": {
+        "review_on_push": true,
+        "review_draft_pull_requests": false
+      }
     },
     {
       "type": "code_scanning",
@@ -25,31 +39,71 @@
         ]
       }
     },
-    { "type": "code_quality", "parameters": { "severity": "errors" } },
+    {
+      "type": "code_quality",
+      "parameters": {
+        "severity": "errors"
+      }
+    },
     {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "Lint & Typecheck", "integration_id": 15368 },
-          { "context": "CodeRabbit", "integration_id": 347564 },
-          { "context": "Test (20.x)", "integration_id": 15368 },
-          { "context": "Test (22.x)", "integration_id": 15368 }
+          {
+            "context": "Lint & Typecheck",
+            "integration_id": 15368
+          },
+          {
+            "context": "CodeRabbit",
+            "integration_id": 347564
+          },
+          {
+            "context": "Test (20.x)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Test (22.x)",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
         ]
       }
     }
   ],
   "node_id": "RRS_lACqUmVwb3NpdG9yec5AmajgzgCbpXk",
   "created_at": "2025-11-20T02:14:51.195-06:00",
-  "updated_at": "2025-11-20T12:58:18.002-06:00",
+  "updated_at": "2025-11-21T16:02:25.629-06:00",
   "bypass_actors": [
-    { "actor_id": null, "actor_type": "OrganizationAdmin", "bypass_mode": "always" },
-    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
+    {
+      "actor_id": null,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
   ],
-  "current_user_can_bypass": "always",
+  "current_user_can_bypass": "pull_requests_only",
   "_links": {
-    "self": { "href": "https://api.github.com/repos/open-hax/codex/rulesets/10200441" },
-    "html": { "href": "https://github.com/open-hax/codex/rules/10200441" }
+    "self": {
+      "href": "https://api.github.com/repos/open-hax/codex/rulesets/10200441"
+    },
+    "html": {
+      "href": "https://github.com/open-hax/codex/rules/10200441"
+    }
   }
 }

--- a/.github/workflows/eta-mu-review-gate.yml
+++ b/.github/workflows/eta-mu-review-gate.yml
@@ -1,0 +1,50 @@
+name: eta-mu-review-gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  coderabbit-review-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+
+      - name: Checkout eta-mu logic
+        uses: actions/checkout@v4
+        with:
+          repository: open-hax/eta-mu-github
+          path: .eta-mu
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: .eta-mu/pnpm-lock.yaml
+
+      - name: Install eta-mu dependencies
+        run: pnpm --dir .eta-mu install --frozen-lockfile
+
+      - name: Enforce review-thread resolution for configured actors
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ETA_MU_REVIEW_ACTORS: ${{ vars.ETA_MU_REVIEW_ACTORS }}
+        run: >-
+          pnpm --dir .eta-mu dev review-gate
+          --repo "${GITHUB_REPOSITORY}"
+          --pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/eta-mu-review-gate.yml
+++ b/.github/workflows/eta-mu-review-gate.yml
@@ -17,28 +17,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Checkout eta-mu logic
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: open-hax/eta-mu-github
           path: .eta-mu
+          ref: 7e63b18cd5fa0dec31491de07f14b22a4851bcc0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: .eta-mu/pnpm-lock.yaml
 
       - name: Install eta-mu dependencies
-        run: pnpm --dir .eta-mu install --frozen-lockfile
+        run: pnpm --dir .eta-mu install --frozen-lockfile --ignore-workspace
 
       - name: Enforce review-thread resolution for configured actors
         env:
@@ -46,5 +47,5 @@ jobs:
           ETA_MU_REVIEW_ACTORS: ${{ vars.ETA_MU_REVIEW_ACTORS }}
         run: >-
           pnpm --dir .eta-mu dev review-gate
-          --repo "${GITHUB_REPOSITORY}"
+          --repo "${{ github.repository }}"
           --pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/eta-mu.yml
+++ b/.github/workflows/eta-mu.yml
@@ -1,0 +1,80 @@
+name: eta-mu
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: eta-mu-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  eta-mu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout eta-mu logic
+        uses: actions/checkout@v4
+        with:
+          repository: open-hax/eta-mu-github
+          path: .eta-mu
+
+      - name: Create eta-mu app token
+        id: eta_mu_token
+        if: ${{ secrets.ETA_MU_APP_ID != '' && secrets.ETA_MU_APP_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ETA_MU_APP_ID }}
+          private-key: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: .eta-mu/pnpm-lock.yaml
+
+      - name: Install eta-mu dependencies
+        run: pnpm --dir .eta-mu install --frozen-lockfile
+
+      - name: Run eta-mu event handler
+        env:
+          GITHUB_TOKEN: ${{ steps.eta_mu_token.outputs.token != '' && steps.eta_mu_token.outputs.token || github.token }}
+          ETA_MU_APP_ID: ${{ secrets.ETA_MU_APP_ID }}
+          ETA_MU_APP_PRIVATE_KEY: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+          ETA_MU_MODEL_PROVIDER: ${{ vars.ETA_MU_MODEL_PROVIDER }}
+          ETA_MU_MODEL_ID: ${{ vars.ETA_MU_MODEL_ID }}
+          ETA_MU_REVIEW_ACTORS: ${{ vars.ETA_MU_REVIEW_ACTORS }}
+          ETA_MU_MENTION_TOKENS: ${{ vars.ETA_MU_MENTION_TOKENS }}
+          ETA_MU_IGNORE_LOGINS: ${{ vars.ETA_MU_IGNORE_LOGINS }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: >-
+          pnpm --dir .eta-mu dev run-event
+          --repo "${GITHUB_REPOSITORY}"
+          --event-name "${GITHUB_EVENT_NAME}"
+          --event-path "${GITHUB_EVENT_PATH}"
+          --cwd "$PWD"

--- a/.github/workflows/eta-mu.yml
+++ b/.github/workflows/eta-mu.yml
@@ -24,42 +24,71 @@ concurrency:
 jobs:
   eta-mu:
     runs-on: ubuntu-latest
+    env:
+      ETA_MU_APP_ID_PRESENT: ${{ secrets.ETA_MU_APP_ID != '' && 'true' || 'false' }}
+      ETA_MU_APP_PRIVATE_KEY_PRESENT: ${{ secrets.ETA_MU_APP_PRIVATE_KEY != '' && 'true' || 'false' }}
+      OPENAI_API_KEY_PRESENT: ${{ secrets.OPENAI_API_KEY != '' && 'true' || 'false' }}
+      ANTHROPIC_API_KEY_PRESENT: ${{ secrets.ANTHROPIC_API_KEY != '' && 'true' || 'false' }}
+      GEMINI_API_KEY_PRESENT: ${{ secrets.GEMINI_API_KEY != '' && 'true' || 'false' }}
+      OPEN_HAX_OPENAI_PROXY_AUTH_TOKEN_PRESENT: ${{ secrets.OPEN_HAX_OPENAI_PROXY_AUTH_TOKEN != '' && 'true' || 'false' }}
     steps:
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Checkout eta-mu logic
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: open-hax/eta-mu-github
           path: .eta-mu
+          ref: 7e63b18cd5fa0dec31491de07f14b22a4851bcc0
 
       - name: Create eta-mu app token
         id: eta_mu_token
-        if: ${{ secrets.ETA_MU_APP_ID != '' && secrets.ETA_MU_APP_PRIVATE_KEY != '' }}
-        uses: actions/create-github-app-token@v1
+        if: ${{ env.ETA_MU_APP_ID_PRESENT == 'true' && env.ETA_MU_APP_PRIVATE_KEY_PRESENT == 'true' }}
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
         with:
           app-id: ${{ secrets.ETA_MU_APP_ID }}
           private-key: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.14.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: .eta-mu/pnpm-lock.yaml
 
       - name: Install eta-mu dependencies
-        run: pnpm --dir .eta-mu install --frozen-lockfile
+        run: pnpm --dir .eta-mu install --frozen-lockfile --ignore-workspace
+
+      - name: Check eta-mu runtime credentials
+        id: eta_mu_runtime
+        shell: bash
+        env:
+          ETA_MU_MODEL_PROVIDER: ${{ vars.ETA_MU_MODEL_PROVIDER }}
+          ETA_MU_MODEL_ID: ${{ vars.ETA_MU_MODEL_ID }}
+          OPEN_HAX_OPENAI_PROXY_URL: ${{ vars.OPEN_HAX_OPENAI_PROXY_URL }}
+        run: |
+          if [[ -n "$ETA_MU_MODEL_PROVIDER" || -n "$ETA_MU_MODEL_ID" || -n "$OPEN_HAX_OPENAI_PROXY_URL" ]]; then
+            if [[ "$OPENAI_API_KEY_PRESENT" == "true" || "$ANTHROPIC_API_KEY_PRESENT" == "true" || "$GEMINI_API_KEY_PRESENT" == "true" || "$OPEN_HAX_OPENAI_PROXY_AUTH_TOKEN_PRESENT" == "true" ]]; then
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "run=false" >> "$GITHUB_OUTPUT"
+          echo "Skipping eta-mu event handler because model configuration or provider credentials are absent."
 
       - name: Run eta-mu event handler
+        if: ${{ steps.eta_mu_runtime.outputs.run == 'true' }}
         env:
           GITHUB_TOKEN: ${{ steps.eta_mu_token.outputs.token != '' && steps.eta_mu_token.outputs.token || github.token }}
           ETA_MU_APP_ID: ${{ secrets.ETA_MU_APP_ID }}
@@ -69,12 +98,14 @@ jobs:
           ETA_MU_REVIEW_ACTORS: ${{ vars.ETA_MU_REVIEW_ACTORS }}
           ETA_MU_MENTION_TOKENS: ${{ vars.ETA_MU_MENTION_TOKENS }}
           ETA_MU_IGNORE_LOGINS: ${{ vars.ETA_MU_IGNORE_LOGINS }}
+          OPEN_HAX_OPENAI_PROXY_URL: ${{ vars.OPEN_HAX_OPENAI_PROXY_URL }}
+          OPEN_HAX_OPENAI_PROXY_AUTH_TOKEN: ${{ secrets.OPEN_HAX_OPENAI_PROXY_AUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: >-
           pnpm --dir .eta-mu dev run-event
-          --repo "${GITHUB_REPOSITORY}"
-          --event-name "${GITHUB_EVENT_NAME}"
-          --event-path "${GITHUB_EVENT_PATH}"
+          --repo "${{ github.repository }}"
+          --event-name "${{ github.event_name }}"
+          --event-path "${{ github.event_path }}"
           --cwd "$PWD"


### PR DESCRIPTION
## Summary
- add the shared `eta-mu` event workflow wrapper
- add the `eta-mu-review-gate` workflow so unresolved CodeRabbit review threads can become a required merge gate

## Notes
- intended required check context: `coderabbit-review-gate`
- intended branch protection still relies on native review-thread resolution as well
- rollout source: `open-hax/codex` via devel automation